### PR TITLE
migrate to manifest v3, update csrf-token extract for compatibility with v3 manifest changes

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,11 +1,11 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
 
   "name": "I don't have time for Bamboo",
   "description": "Extensions to help filling Bamboo Timesheet",
-  "version": "1.0",
+  "version": "1.1.0",
 
-  "browser_action": {
+  "action": {
     "default_icon": "icon.png",
     "default_popup": "popup.html"
   },
@@ -18,8 +18,16 @@
   ],
 
   "background": {
-    "scripts": ["js/vendor.js", "js/background.js"]
+    "service_worker": "js/background.js"
   },
 
-  "permissions": ["storage", "webRequest", "*://*.bamboohr.com/*"]
+  "permissions": ["storage", "webRequest"],
+
+  "host_permissions": [
+    "https://*.bamboohr.com/*"
+  ],
+
+  "content_security_policy": {
+    "extension_page": "script-src 'unsafe-inline'"
+  }
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,5 +1,17 @@
 let lastSavedEntry: string | null = null;
 let lastSavedURL: string | null = null;
+let csrfToken: string | null | undefined = null;
+
+chrome.webRequest.onBeforeSendHeaders.addListener(
+  (details) => {
+    if (!csrfToken) {
+      const csrfTokenHeader = details.requestHeaders!.find(x => x.name === 'X-CSRF-TOKEN')
+      csrfToken = csrfTokenHeader?.value
+    }
+  },
+  { urls: ["*://*.bamboohr.com/timesheet/clock/entries"] },
+  ["requestHeaders"]
+);
 
 chrome.webRequest.onBeforeRequest.addListener(
   (details) => {
@@ -36,7 +48,7 @@ chrome.runtime.onMessage.addListener(function (request, _, responder) {
         responder({ type: "NOT_READY" });
         return;
       }
-      responder({ type: "OK", data: lastSavedEntry, url: lastSavedURL });
+      responder({ type: "OK", data: lastSavedEntry, url: lastSavedURL, csrfToken: csrfToken });
       break;
   }
 });

--- a/src/content_script.tsx
+++ b/src/content_script.tsx
@@ -1,13 +1,5 @@
 import axios from "axios";
 
-function readCSRF() {
-  const j = document.createElement("script"),
-    f = document.getElementsByTagName("script")[0];
-  j.textContent = "document.body.setAttribute('data-csrf', CSRF_TOKEN)";
-  f.parentNode && f.parentNode.insertBefore(j, f);
-  f.parentNode && f.parentNode.removeChild(j);
-}
-
 function processDate(date: string, btn: HTMLButtonElement) {
   chrome.runtime.sendMessage({ type: "PROCESS_REQUEST" }, async (payload) => {
     if (payload.type === "NOT_READY") {
@@ -24,7 +16,7 @@ function processDate(date: string, btn: HTMLButtonElement) {
       try {
         const res = await axios.post(url, data, {
           headers: {
-            "x-csrf-token": document.body.getAttribute("data-csrf"),
+            "x-csrf-token": payload.csrfToken,
           },
         });
         console.log(res);
@@ -42,7 +34,6 @@ function processDate(date: string, btn: HTMLButtonElement) {
 }
 
 window.addEventListener("load", function () {
-  readCSRF();
   const data = document.getElementById("js-timesheet-data");
   if (!data) {
     alert("helo");


### PR DESCRIPTION
The webstore no longer allows uploads of v2 manifest extensions. The following changes are for v3 compatiblity, in particular it appears you can no longer easily inject a script into the host page from the content script, which breaks how the csrf token was being extracted.

The CSRF token is now extracted from the _preparation_ entry web request instead of through the script workaround.